### PR TITLE
Upgrade to JOML 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Switched to MIT license (57f20622f1be542544714066bac816fc98459b34)
-- Tested on LWJGL 3.1.0 build 40 and JOML 1.8.3
+- Tested on LWJGL 3.1.0 build 40 and JOML 1.9.0
 
 ### Fixed
 - Updated link to LM3DGP in `README.md` (e67ddda9f06dbb3bc9c62cec44b83490e40f63cb)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To compile and run the code, you will need:
 
 - Java SE Development Kit 8
 - [LWJGL 3.1.0 build 40](https://www.lwjgl.org/download)
-- [JOML 1.8.3](https://github.com/JOML-CI/JOML/releases/tag/1.8.3)
+- [JOML 1.9.0](https://github.com/JOML-CI/JOML/releases/tag/1.9.0)
 
 Working with different versions of LJWGL 3 or JOML may require adjustments to the code. If you are stuck with LWJGL 2, check the release [v0.9.1](https://github.com/integeruser/jgltut/releases/tag/v0.9.1) of this repository.
 
@@ -21,7 +21,7 @@ Create a new Java project using your favorite IDE, then:
 
 1. Import the source code of this repository;
 2. Download LWJGL from the link above, then add `lwjgl.jar` and the other JARs to the classpath and link the native libraries, as explained in the [official guide](https://www.lwjgl.org/guide);
-3. Download `joml-1.8.3.jar` from the link above, then add it to the classpath as in the previous step.
+3. Download `joml-1.9.0.jar` from the link above, then add it to the classpath as in the previous step.
 
 Finally, run the `main` method of the first tutorial `integeruser.jgltut.tut01.Tut1.java` and check the output in the console window. If your graphics card does not meet the minimum requirements (checked using the LWJGL helper `GL.getCapabilities().OpenGL33`), the message `You must have at least OpenGL 3.3 to run this tutorial.` will appear; otherwise, if no other errors show up, you can start playing with the other tutorials by running the `main` method of `integeruser.jgltut.TutorialChooser.java`. To quit any tutorial simply press `ESC`.
 


### PR DESCRIPTION
You can upgrade to the latest JOML 1.9.0 without problems.
Changes between 1.8.3 and 1.9.0 do not affect the demos.